### PR TITLE
polyfills are correctly resolved now, but some crypto polyfill is not implemented yet

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -71,13 +71,13 @@ export default defineNuxtConfig({
     defaultImport: 'component',
     global: false,
   },
-  ssr: true,
+  ssr: false,
   vite: {
     define: {
       process: {},
       global: 'globalThis',
     },
-    // This is not ideal and should work via `unenv` directly..
+    // This is not ideal and should work via `unenv` directly.
     resolve: {
       alias: {
         crypto: './node_modules/unenv/runtime/node/crypto/node.cjs',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -81,7 +81,7 @@ export default defineNuxtConfig({
     resolve: {
       alias: {
         crypto: './node_modules/unenv/runtime/node/crypto/node.cjs',
-        // assert: './node_modules/unenv/runtime/mock/proxy.cjs',
+        assert: './node_modules/unenv/runtime/mock/proxy.cjs',
         http: './node_modules/unenv/runtime/node/http/index.cjs',
         buffer: './node_modules/unenv/runtime/node/buffer/index.cjs',
         os: './node_modules/unenv/runtime/mock/proxy.cjs',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,8 +1,6 @@
 import { defineNuxtConfig } from 'nuxt/config'
 
-// Add polyfills: https://github.com/nuxt/nuxt/pull/25028
-import { Buffer } from 'node:buffer'
-import process from 'node:process'
+import 'node:crypto';
 
 export default defineNuxtConfig({
   app: {
@@ -61,7 +59,7 @@ export default defineNuxtConfig({
     externalVue: false,
   },
   routeRules: {
-    '/': { ssr: false },
+    '/': { ssr: true },
   },
   imports: {
     autoImport: false,
@@ -73,7 +71,32 @@ export default defineNuxtConfig({
     defaultImport: 'component',
     global: false,
   },
+  ssr: true,
   vite: {
+    define: {
+      process: {},
+      global: 'globalThis',
+    },
+    // This is not ideal and should work via `unenv` directly..
+    resolve: {
+      alias: {
+        crypto: './node_modules/unenv/runtime/node/crypto/node.cjs',
+        // assert: './node_modules/unenv/runtime/mock/proxy.cjs',
+        http: './node_modules/unenv/runtime/node/http/index.cjs',
+        buffer: './node_modules/unenv/runtime/node/buffer/index.cjs',
+        os: './node_modules/unenv/runtime/mock/proxy.cjs',
+        url: './node_modules/unenv/runtime/node/url/index.cjs',
+        zlib: './node_modules/unenv/runtime/mock/proxy.cjs',
+        'process/': './node_modules/unenv/runtime/mock/proxy.cjs',
+        process: './node_modules/unenv/runtime/mock/proxy.cjs',
+        stream: './node_modules/unenv/runtime/mock/proxy.cjs',
+        _stream_duplex: './node_modules/unenv/runtime/mock/proxy.cjs',
+        _stream_passthrough: './node_modules/unenv/runtime/mock/proxy.cjs',
+        _stream_readable: './node_modules/unenv/runtime/mock/proxy.cjs',
+        _stream_writable: './node_modules/unenv/runtime/mock/proxy.cjs',
+        _stream_transform: './node_modules/unenv/runtime/mock/proxy.cjs',
+      },
+    },
     css: {
       preprocessorOptions: {
         scss: {

--- a/package.json
+++ b/package.json
@@ -21,13 +21,12 @@
     "nuxt": "^3.11.2",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.3",
-    "unenv": "^1.9.0",
     "vite": "^5.2.10",
     "vue": "^3.4.26",
     "vue-router": "^4.3.2"
   },
   "dependencies": {
-    "@encointer/worker-api": "^0.12.4",
+    "@encointer/worker-api": "^0.12.5-alpha.0",
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
     "@material-tailwind/html": "^2.2.2",
     "@nuxt/content": "^2.12.1",
@@ -50,6 +49,7 @@
     "nuxt-svgo": "^4.0.0",
     "pinia": "^2.1.7",
     "sass": "^1.75.0",
+    "unenv": "^1.9.0",
     "vue3-form-wizard": "^0.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "vue-router": "^4.3.2"
   },
   "dependencies": {
-    "@encointer/worker-api": "^0.12.5-alpha.0",
+    "@encointer/worker-api": "^0.12.5-alpha.1",
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
     "@material-tailwind/html": "^2.2.2",
     "@nuxt/content": "^2.12.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "vue-router": "^4.3.2"
   },
   "dependencies": {
-    "@encointer/worker-api": "^0.12.5-alpha.1",
+    "@encointer/worker-api": "^0.12.5-alpha.4",
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
     "@material-tailwind/html": "^2.2.2",
     "@nuxt/content": "^2.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -485,32 +485,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@encointer/node-api@npm:^0.12.4":
-  version: 0.12.4
-  resolution: "@encointer/node-api@npm:0.12.4"
+"@encointer/node-api@npm:^0.12.5-alpha.1":
+  version: 0.12.5-alpha.1
+  resolution: "@encointer/node-api@npm:0.12.5-alpha.1"
   dependencies:
-    "@encointer/types": "npm:^0.12.4"
+    "@encointer/types": "npm:^0.12.5-alpha.1"
     "@polkadot/api": "npm:^10.9.1"
     tslib: "npm:^2.5.3"
-  checksum: 10c0/7a9c15edfb49b757ebb7ca6341a0e1d533dd48834242db9da8a1f77091d380f4966b0aa8d53f2c27b2b96716c5e49e39e083f403b22e4072d80f8c799b94a181
+  checksum: 10c0/e629010b6bc707eb8263119940786f962adcff74afc418e76406f1dbbe0244c35a3701e4787ffd07fae86e14d856374d5d1752a3323982acd06da4a951142371
   languageName: node
   linkType: hard
 
-"@encointer/types@npm:^0.12.4":
-  version: 0.12.4
-  resolution: "@encointer/types@npm:0.12.4"
+"@encointer/types@npm:^0.12.5-alpha.1":
+  version: 0.12.5-alpha.1
+  resolution: "@encointer/types@npm:0.12.5-alpha.1"
   dependencies:
     "@polkadot/api": "npm:^10.9.1"
     "@polkadot/types": "npm:^10.9.1"
     "@polkadot/types-codec": "npm:^10.9.1"
     "@polkadot/util": "npm:^12.3.2"
-  checksum: 10c0/2263d64e704257c4ceb018dd84ad8133c04f4f1ce3dfe6490cfdbb84f9b50fda35303bc073010a85ef10f050c0ea0d0c1800ef80587e680d6501ad710e3cd158
+  checksum: 10c0/cb1a0bff1051a9c6bedd2de16d86f7e04ab94fff65895b1a6ebc6ff403f6dd7bc19f49bfa0c8100baae1f0bc0af1528c0578efe80e306477434619e37aa386b0
   languageName: node
   linkType: hard
 
-"@encointer/util@npm:^0.12.4":
-  version: 0.12.4
-  resolution: "@encointer/util@npm:0.12.4"
+"@encointer/util@npm:^0.12.5-alpha.1":
+  version: 0.12.5-alpha.1
+  resolution: "@encointer/util@npm:0.12.5-alpha.1"
   dependencies:
     "@babel/runtime": "npm:^7.18.9"
     "@polkadot/util": "npm:^12.3.2"
@@ -518,18 +518,18 @@ __metadata:
     "@types/bn.js": "npm:^5.1.1"
     assert: "npm:^2.0.0"
     bn.js: "npm:^5.2.1"
-  checksum: 10c0/d3e1981d9990ff4ca3e86c9b44b69c3634d5c045fea48bfe6eeed56c6a51ad77543abb3bd6d057a8e8b3c5ded05ddccd852a390ae3a2b550a5a5528537500786
+  checksum: 10c0/f035e548b67265d95f15c6237686654a4191a3db08a7a77694f91ab17e588d8b2afe210269000fd9186673d9373d76e452c845257823cd2432bc38d80301c4af
   languageName: node
   linkType: hard
 
-"@encointer/worker-api@npm:^0.12.4":
-  version: 0.12.4
-  resolution: "@encointer/worker-api@npm:0.12.4"
+"@encointer/worker-api@npm:^0.12.5-alpha.1":
+  version: 0.12.5-alpha.1
+  resolution: "@encointer/worker-api@npm:0.12.5-alpha.1"
   dependencies:
-    "@encointer/node-api": "npm:^0.12.4"
-    "@encointer/types": "npm:^0.12.4"
-    "@encointer/util": "npm:^0.12.4"
-    "@learntheropes/node-rsa": "npm:^1.1.3"
+    "@encointer/node-api": "npm:^0.12.5-alpha.1"
+    "@encointer/types": "npm:^0.12.5-alpha.1"
+    "@encointer/util": "npm:^0.12.5-alpha.1"
+    "@learntheropes/node-rsa": "npm:~1.1.3"
     "@polkadot/api": "npm:^10.9.1"
     "@polkadot/keyring": "npm:^12.3.2"
     "@polkadot/types": "npm:^10.9.1"
@@ -542,7 +542,7 @@ __metadata:
     websocket-as-promised: "npm:^2.0.1"
   peerDependencies:
     "@polkadot/x-randomvalues": ^12.3.2
-  checksum: 10c0/e720c1fbdb4f6467e48b0bbbda1649c26fe68639e8e19ab3007f87ee75ea009d0becf75f5644cb3b3ac1e8ae1dc8957174994957239cf387ec59ae2ec9a25905
+  checksum: 10c0/1144351c081006d2d27b4f84c61fe0fc9591e660e21eeb0ffb3234a6bd708a5b62924e2e7c5ad08740b0e89541f526f6e7693aee68bcc664b0d7098ffb7c9aca
   languageName: node
   linkType: hard
 
@@ -912,7 +912,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@learntheropes/node-rsa@npm:^1.1.3":
+"@learntheropes/node-rsa@npm:~1.1.3":
   version: 1.1.3
   resolution: "@learntheropes/node-rsa@npm:1.1.3"
   dependencies:
@@ -8588,7 +8588,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "nuxt-app@workspace:."
   dependencies:
-    "@encointer/worker-api": "npm:^0.12.4"
+    "@encointer/worker-api": "npm:^0.12.5-alpha.1"
     "@esbuild-plugins/node-globals-polyfill": "npm:^0.2.3"
     "@material-tailwind/html": "npm:^2.2.2"
     "@nuxt/content": "npm:^2.12.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -485,32 +485,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@encointer/node-api@npm:^0.12.5-alpha.1":
-  version: 0.12.5-alpha.1
-  resolution: "@encointer/node-api@npm:0.12.5-alpha.1"
+"@encointer/node-api@npm:^0.12.5-alpha.4":
+  version: 0.12.5-alpha.4
+  resolution: "@encointer/node-api@npm:0.12.5-alpha.4"
   dependencies:
-    "@encointer/types": "npm:^0.12.5-alpha.1"
+    "@encointer/types": "npm:^0.12.5-alpha.4"
     "@polkadot/api": "npm:^10.9.1"
     tslib: "npm:^2.5.3"
-  checksum: 10c0/e629010b6bc707eb8263119940786f962adcff74afc418e76406f1dbbe0244c35a3701e4787ffd07fae86e14d856374d5d1752a3323982acd06da4a951142371
+  checksum: 10c0/f623da640795621ddd568655bfd1712d085a0d0f94cbc5a03022f157a3e9489406012a9a760b9cc73ef3c9da875d955df5593b47edccb89dd0ea8401389a13f1
   languageName: node
   linkType: hard
 
-"@encointer/types@npm:^0.12.5-alpha.1":
-  version: 0.12.5-alpha.1
-  resolution: "@encointer/types@npm:0.12.5-alpha.1"
+"@encointer/types@npm:^0.12.5-alpha.4":
+  version: 0.12.5-alpha.4
+  resolution: "@encointer/types@npm:0.12.5-alpha.4"
   dependencies:
     "@polkadot/api": "npm:^10.9.1"
     "@polkadot/types": "npm:^10.9.1"
     "@polkadot/types-codec": "npm:^10.9.1"
     "@polkadot/util": "npm:^12.3.2"
-  checksum: 10c0/cb1a0bff1051a9c6bedd2de16d86f7e04ab94fff65895b1a6ebc6ff403f6dd7bc19f49bfa0c8100baae1f0bc0af1528c0578efe80e306477434619e37aa386b0
+  checksum: 10c0/5ab3cceecb6efefdcb922c325b160de4592601bdfa93d887975df4b230f895f391e0545bb36a1a8ead9ec4814f79606f51a0755bbf51ce6273fe18bf1470436f
   languageName: node
   linkType: hard
 
-"@encointer/util@npm:^0.12.5-alpha.1":
-  version: 0.12.5-alpha.1
-  resolution: "@encointer/util@npm:0.12.5-alpha.1"
+"@encointer/util@npm:^0.12.5-alpha.4":
+  version: 0.12.5-alpha.4
+  resolution: "@encointer/util@npm:0.12.5-alpha.4"
   dependencies:
     "@babel/runtime": "npm:^7.18.9"
     "@polkadot/util": "npm:^12.3.2"
@@ -518,17 +518,17 @@ __metadata:
     "@types/bn.js": "npm:^5.1.1"
     assert: "npm:^2.0.0"
     bn.js: "npm:^5.2.1"
-  checksum: 10c0/f035e548b67265d95f15c6237686654a4191a3db08a7a77694f91ab17e588d8b2afe210269000fd9186673d9373d76e452c845257823cd2432bc38d80301c4af
+  checksum: 10c0/a2038788f0ad86b5e46198e132a05e8f7faa88aaf0a3ae4c58a5dd9f1e6fd40dbcb625df069732d47b86fc819405fbd5efd66d46101c34767fc4ee0a57585c43
   languageName: node
   linkType: hard
 
-"@encointer/worker-api@npm:^0.12.5-alpha.1":
-  version: 0.12.5-alpha.1
-  resolution: "@encointer/worker-api@npm:0.12.5-alpha.1"
+"@encointer/worker-api@npm:^0.12.5-alpha.4":
+  version: 0.12.5-alpha.4
+  resolution: "@encointer/worker-api@npm:0.12.5-alpha.4"
   dependencies:
-    "@encointer/node-api": "npm:^0.12.5-alpha.1"
-    "@encointer/types": "npm:^0.12.5-alpha.1"
-    "@encointer/util": "npm:^0.12.5-alpha.1"
+    "@encointer/node-api": "npm:^0.12.5-alpha.4"
+    "@encointer/types": "npm:^0.12.5-alpha.4"
+    "@encointer/util": "npm:^0.12.5-alpha.4"
     "@learntheropes/node-rsa": "npm:~1.1.3"
     "@polkadot/api": "npm:^10.9.1"
     "@polkadot/keyring": "npm:^12.3.2"
@@ -542,7 +542,7 @@ __metadata:
     websocket-as-promised: "npm:^2.0.1"
   peerDependencies:
     "@polkadot/x-randomvalues": ^12.3.2
-  checksum: 10c0/1144351c081006d2d27b4f84c61fe0fc9591e660e21eeb0ffb3234a6bd708a5b62924e2e7c5ad08740b0e89541f526f6e7693aee68bcc664b0d7098ffb7c9aca
+  checksum: 10c0/0ed5484e841ab9e879072eafcc4e0571a999bea28268bd7da05cddfd729829afb02800af236769d72085de1af43a5bc5a107f5c944e951b4fe71fe52ce3c7b62
   languageName: node
   linkType: hard
 
@@ -8588,7 +8588,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "nuxt-app@workspace:."
   dependencies:
-    "@encointer/worker-api": "npm:^0.12.5-alpha.1"
+    "@encointer/worker-api": "npm:^0.12.5-alpha.4"
     "@esbuild-plugins/node-globals-polyfill": "npm:^0.2.3"
     "@material-tailwind/html": "npm:^2.2.2"
     "@nuxt/content": "npm:^2.12.1"


### PR DESCRIPTION
Blocker: https://github.com/unjs/unenv/issues/177

Currently getting the following error during encryption:

```console
 Error: Error during encryption. Original error: Error: [unenv] crypto.createHash is not implemented yet!
```

Workarounds:
* (again) try to make the vite-polyfils-plugin working (or maybe a combination of unenv/vite), created bug report: https://github.com/davidmyersdev/vite-plugin-node-polyfills/issues/92
* migrate crypto in encointer-js to another lib
* maybe the node-rsa v1.1.2 with its own polyfills can resolve the issue: https://github.com/rzcoder/node-rsa/issues/234
* ~~use `clientNodeCompat: true`:~~  won't work, it uses unenv under the hood, see #11