### PR TITLE
Client side node js support

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -58,6 +58,7 @@ export default defineNuxtConfig({
     },
   },
   experimental: {
+    clientNodeCompat: true,
     externalVue: false,
   },
   routeRules: {
@@ -73,6 +74,7 @@ export default defineNuxtConfig({
     defaultImport: 'component',
     global: false,
   },
+  ssr: false,
   vite: {
     css: {
       preprocessorOptions: {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "vue-router": "^4.3.2"
   },
   "dependencies": {
-    "@encointer/worker-api": "^0.12.4",
+    "@encointer/worker-api": "^0.12.5-alpha.3",
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
     "@material-tailwind/html": "^2.2.2",
     "@nuxt/content": "^2.12.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "vue-router": "^4.3.2"
   },
   "dependencies": {
-    "@encointer/worker-api": "^0.12.5-alpha.3",
+    "@encointer/worker-api": "^0.12.5-alpha.4",
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
     "@material-tailwind/html": "^2.2.2",
     "@nuxt/content": "^2.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -485,32 +485,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@encointer/node-api@npm:^0.12.5-alpha.3":
-  version: 0.12.5-alpha.3
-  resolution: "@encointer/node-api@npm:0.12.5-alpha.3"
+"@encointer/node-api@npm:^0.12.5-alpha.4":
+  version: 0.12.5-alpha.4
+  resolution: "@encointer/node-api@npm:0.12.5-alpha.4"
   dependencies:
-    "@encointer/types": "npm:^0.12.5-alpha.3"
+    "@encointer/types": "npm:^0.12.5-alpha.4"
     "@polkadot/api": "npm:^10.9.1"
     tslib: "npm:^2.5.3"
-  checksum: 10c0/8aac7c5a44779f1975d5cdb63fa8d2e15095870ff6e2caa12442f962e842ba581fe9a62390256bf7317dbfd99bf61892a27d3310a1102158882a0e78ab7c2a0d
+  checksum: 10c0/f623da640795621ddd568655bfd1712d085a0d0f94cbc5a03022f157a3e9489406012a9a760b9cc73ef3c9da875d955df5593b47edccb89dd0ea8401389a13f1
   languageName: node
   linkType: hard
 
-"@encointer/types@npm:^0.12.5-alpha.3":
-  version: 0.12.5-alpha.3
-  resolution: "@encointer/types@npm:0.12.5-alpha.3"
+"@encointer/types@npm:^0.12.5-alpha.4":
+  version: 0.12.5-alpha.4
+  resolution: "@encointer/types@npm:0.12.5-alpha.4"
   dependencies:
     "@polkadot/api": "npm:^10.9.1"
     "@polkadot/types": "npm:^10.9.1"
     "@polkadot/types-codec": "npm:^10.9.1"
     "@polkadot/util": "npm:^12.3.2"
-  checksum: 10c0/875b0a554a328d8c0f76d36d97d3f06090b9279bcd8c79f910269bcc92917a793e2c61f474e396d2ba152fb1798ad7823ba7fb7ed6ba62e818cfc7b5a23ed025
+  checksum: 10c0/5ab3cceecb6efefdcb922c325b160de4592601bdfa93d887975df4b230f895f391e0545bb36a1a8ead9ec4814f79606f51a0755bbf51ce6273fe18bf1470436f
   languageName: node
   linkType: hard
 
-"@encointer/util@npm:^0.12.5-alpha.3":
-  version: 0.12.5-alpha.3
-  resolution: "@encointer/util@npm:0.12.5-alpha.3"
+"@encointer/util@npm:^0.12.5-alpha.4":
+  version: 0.12.5-alpha.4
+  resolution: "@encointer/util@npm:0.12.5-alpha.4"
   dependencies:
     "@babel/runtime": "npm:^7.18.9"
     "@polkadot/util": "npm:^12.3.2"
@@ -518,17 +518,17 @@ __metadata:
     "@types/bn.js": "npm:^5.1.1"
     assert: "npm:^2.0.0"
     bn.js: "npm:^5.2.1"
-  checksum: 10c0/df9a0b58206344a2406949e23f48bd99a0f562a6def46f33ac765b1a56ee2d0ecb219645c8ee29544d49f5dc3ecdb520a77fb94de7bf797209db8cadedd5a6d6
+  checksum: 10c0/a2038788f0ad86b5e46198e132a05e8f7faa88aaf0a3ae4c58a5dd9f1e6fd40dbcb625df069732d47b86fc819405fbd5efd66d46101c34767fc4ee0a57585c43
   languageName: node
   linkType: hard
 
-"@encointer/worker-api@npm:^0.12.5-alpha.3":
-  version: 0.12.5-alpha.3
-  resolution: "@encointer/worker-api@npm:0.12.5-alpha.3"
+"@encointer/worker-api@npm:^0.12.5-alpha.4":
+  version: 0.12.5-alpha.4
+  resolution: "@encointer/worker-api@npm:0.12.5-alpha.4"
   dependencies:
-    "@encointer/node-api": "npm:^0.12.5-alpha.3"
-    "@encointer/types": "npm:^0.12.5-alpha.3"
-    "@encointer/util": "npm:^0.12.5-alpha.3"
+    "@encointer/node-api": "npm:^0.12.5-alpha.4"
+    "@encointer/types": "npm:^0.12.5-alpha.4"
+    "@encointer/util": "npm:^0.12.5-alpha.4"
     "@learntheropes/node-rsa": "npm:~1.1.3"
     "@polkadot/api": "npm:^10.9.1"
     "@polkadot/keyring": "npm:^12.3.2"
@@ -542,7 +542,7 @@ __metadata:
     websocket-as-promised: "npm:^2.0.1"
   peerDependencies:
     "@polkadot/x-randomvalues": ^12.3.2
-  checksum: 10c0/42a5959d2dc21f231acd8ee18611bd16a83342c99db1debadf9f8b6c34bca5775edb3d3128b3702a8649c7d0cda927957b5e85e8957a54e6cdfad7ea37e95cdb
+  checksum: 10c0/0ed5484e841ab9e879072eafcc4e0571a999bea28268bd7da05cddfd729829afb02800af236769d72085de1af43a5bc5a107f5c944e951b4fe71fe52ce3c7b62
   languageName: node
   linkType: hard
 
@@ -8588,7 +8588,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "nuxt-app@workspace:."
   dependencies:
-    "@encointer/worker-api": "npm:^0.12.5-alpha.3"
+    "@encointer/worker-api": "npm:^0.12.5-alpha.4"
     "@esbuild-plugins/node-globals-polyfill": "npm:^0.2.3"
     "@material-tailwind/html": "npm:^2.2.2"
     "@nuxt/content": "npm:^2.12.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -485,32 +485,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@encointer/node-api@npm:^0.12.4":
-  version: 0.12.4
-  resolution: "@encointer/node-api@npm:0.12.4"
+"@encointer/node-api@npm:^0.12.5-alpha.3":
+  version: 0.12.5-alpha.3
+  resolution: "@encointer/node-api@npm:0.12.5-alpha.3"
   dependencies:
-    "@encointer/types": "npm:^0.12.4"
+    "@encointer/types": "npm:^0.12.5-alpha.3"
     "@polkadot/api": "npm:^10.9.1"
     tslib: "npm:^2.5.3"
-  checksum: 10c0/7a9c15edfb49b757ebb7ca6341a0e1d533dd48834242db9da8a1f77091d380f4966b0aa8d53f2c27b2b96716c5e49e39e083f403b22e4072d80f8c799b94a181
+  checksum: 10c0/8aac7c5a44779f1975d5cdb63fa8d2e15095870ff6e2caa12442f962e842ba581fe9a62390256bf7317dbfd99bf61892a27d3310a1102158882a0e78ab7c2a0d
   languageName: node
   linkType: hard
 
-"@encointer/types@npm:^0.12.4":
-  version: 0.12.4
-  resolution: "@encointer/types@npm:0.12.4"
+"@encointer/types@npm:^0.12.5-alpha.3":
+  version: 0.12.5-alpha.3
+  resolution: "@encointer/types@npm:0.12.5-alpha.3"
   dependencies:
     "@polkadot/api": "npm:^10.9.1"
     "@polkadot/types": "npm:^10.9.1"
     "@polkadot/types-codec": "npm:^10.9.1"
     "@polkadot/util": "npm:^12.3.2"
-  checksum: 10c0/2263d64e704257c4ceb018dd84ad8133c04f4f1ce3dfe6490cfdbb84f9b50fda35303bc073010a85ef10f050c0ea0d0c1800ef80587e680d6501ad710e3cd158
+  checksum: 10c0/875b0a554a328d8c0f76d36d97d3f06090b9279bcd8c79f910269bcc92917a793e2c61f474e396d2ba152fb1798ad7823ba7fb7ed6ba62e818cfc7b5a23ed025
   languageName: node
   linkType: hard
 
-"@encointer/util@npm:^0.12.4":
-  version: 0.12.4
-  resolution: "@encointer/util@npm:0.12.4"
+"@encointer/util@npm:^0.12.5-alpha.3":
+  version: 0.12.5-alpha.3
+  resolution: "@encointer/util@npm:0.12.5-alpha.3"
   dependencies:
     "@babel/runtime": "npm:^7.18.9"
     "@polkadot/util": "npm:^12.3.2"
@@ -518,18 +518,18 @@ __metadata:
     "@types/bn.js": "npm:^5.1.1"
     assert: "npm:^2.0.0"
     bn.js: "npm:^5.2.1"
-  checksum: 10c0/d3e1981d9990ff4ca3e86c9b44b69c3634d5c045fea48bfe6eeed56c6a51ad77543abb3bd6d057a8e8b3c5ded05ddccd852a390ae3a2b550a5a5528537500786
+  checksum: 10c0/df9a0b58206344a2406949e23f48bd99a0f562a6def46f33ac765b1a56ee2d0ecb219645c8ee29544d49f5dc3ecdb520a77fb94de7bf797209db8cadedd5a6d6
   languageName: node
   linkType: hard
 
-"@encointer/worker-api@npm:^0.12.4":
-  version: 0.12.4
-  resolution: "@encointer/worker-api@npm:0.12.4"
+"@encointer/worker-api@npm:^0.12.5-alpha.3":
+  version: 0.12.5-alpha.3
+  resolution: "@encointer/worker-api@npm:0.12.5-alpha.3"
   dependencies:
-    "@encointer/node-api": "npm:^0.12.4"
-    "@encointer/types": "npm:^0.12.4"
-    "@encointer/util": "npm:^0.12.4"
-    "@learntheropes/node-rsa": "npm:^1.1.3"
+    "@encointer/node-api": "npm:^0.12.5-alpha.3"
+    "@encointer/types": "npm:^0.12.5-alpha.3"
+    "@encointer/util": "npm:^0.12.5-alpha.3"
+    "@learntheropes/node-rsa": "npm:~1.1.3"
     "@polkadot/api": "npm:^10.9.1"
     "@polkadot/keyring": "npm:^12.3.2"
     "@polkadot/types": "npm:^10.9.1"
@@ -542,7 +542,7 @@ __metadata:
     websocket-as-promised: "npm:^2.0.1"
   peerDependencies:
     "@polkadot/x-randomvalues": ^12.3.2
-  checksum: 10c0/e720c1fbdb4f6467e48b0bbbda1649c26fe68639e8e19ab3007f87ee75ea009d0becf75f5644cb3b3ac1e8ae1dc8957174994957239cf387ec59ae2ec9a25905
+  checksum: 10c0/42a5959d2dc21f231acd8ee18611bd16a83342c99db1debadf9f8b6c34bca5775edb3d3128b3702a8649c7d0cda927957b5e85e8957a54e6cdfad7ea37e95cdb
   languageName: node
   linkType: hard
 
@@ -912,7 +912,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@learntheropes/node-rsa@npm:^1.1.3":
+"@learntheropes/node-rsa@npm:~1.1.3":
   version: 1.1.3
   resolution: "@learntheropes/node-rsa@npm:1.1.3"
   dependencies:
@@ -8588,7 +8588,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "nuxt-app@workspace:."
   dependencies:
-    "@encointer/worker-api": "npm:^0.12.4"
+    "@encointer/worker-api": "npm:^0.12.5-alpha.3"
     "@esbuild-plugins/node-globals-polyfill": "npm:^0.2.3"
     "@material-tailwind/html": "npm:^2.2.2"
     "@nuxt/content": "npm:^2.12.1"


### PR DESCRIPTION
This nuxt feature uses unenv under the hood, hence we get the same `createHash is not implemented yet` error